### PR TITLE
Potential fixes for 7 code scanning alerts

### DIFF
--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -64,11 +64,17 @@ export class FileController {
     description: 'save raw content on server as a file',
   })
   @Put('raw')
-  async uploadFile(@Query('path') file, @Body() raw: Buffer): Promise<void> {
+  async uploadFile(@Query('path') filePath: string, @Body() raw: Buffer): Promise<void> {
+    const SAFE_ROOT = '/safe/root/directory';
     try {
       if (typeof raw === 'string' || Buffer.isBuffer(raw)) {
-        await fs.promises.access(path.dirname(file), W_OK);
-        await fs.promises.writeFile(file, raw);
+        const resolvedPath = path.resolve(SAFE_ROOT, filePath);
+        if (!resolvedPath.startsWith(SAFE_ROOT)) {
+          this.logger.error('Invalid file path');
+          return;
+        }
+        await fs.promises.access(path.dirname(resolvedPath), W_OK);
+        await fs.promises.writeFile(resolvedPath, raw);
       }
     } catch (err) {
       this.logger.error(err.message);

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -10,13 +10,13 @@ export class FileService {
   private readonly logger = new Logger(FileService.name);
   private cloudProviders = new CloudProvidersMetaData();
 
+  private readonly ROOT_DIR = path.resolve(process.cwd(), 'safe_root_directory');
+
   async getFile(file: string): Promise<Stream> {
     this.logger.log(`Reading file: ${file}`);
 
     if (file.startsWith('/')) {
-      await fs.promises.access(file, R_OK);
-
-      return fs.createReadStream(file);
+      file = path.resolve(file);
     } else if (file.startsWith('http')) {
       const content = this.cloudProviders.get(file);
 
@@ -26,23 +26,32 @@ export class FileService {
         throw new Error(`no such file or directory, access '${file}'`);
       }
     } else {
-      file = path.resolve(process.cwd(), file);
-
-      await fs.promises.access(file, R_OK);
-
-      return fs.createReadStream(file);
+      file = path.resolve(this.ROOT_DIR, file);
     }
+
+    if (!file.startsWith(this.ROOT_DIR)) {
+      throw new Error('Access to the specified file is not allowed');
+    }
+
+    await fs.promises.access(file, R_OK);
+
+    return fs.createReadStream(file);
   }
 
   async deleteFile(file: string): Promise<boolean> {
     if (file.startsWith('/')) {
-      throw new Error('cannot delete file from this location');
+      file = path.resolve(file);
     } else if (file.startsWith('http')) {
       throw new Error('cannot delete file from this location');
     } else {
-      file = path.resolve(process.cwd(), file);
-      await fs.promises.unlink(file);
-      return true;
+      file = path.resolve(this.ROOT_DIR, file);
     }
+
+    if (!file.startsWith(this.ROOT_DIR)) {
+      throw new Error('Access to the specified file is not allowed');
+    }
+
+    await fs.promises.unlink(file);
+    return true;
   }
 }


### PR DESCRIPTION
Potential fixes for 7 code scanning alerts from the [Mitre top 10 KEV](https://github.com/orgs/octodemo/security/campaigns/236) security campaign:
- https://github.com/octodemo/brokencrystals/security/code-scanning/9
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the `file` path is validated to be within a safe root directory after it is resolved. This can be done by:
    1. Defining a safe root directory.
    2. Normalizing the `file` path using `path.resolve`.
    3. Checking that the normalized path starts with the safe root directory.

    We will apply these changes to both the `getFile` and `deleteFile` methods in `FileService`.
    
  </details>


- https://github.com/octodemo/brokencrystals/security/code-scanning/8
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This involves normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. If the path is not within the root directory, we should throw an error or return an appropriate response.

    1. Define a safe root directory.
    2. Normalize the file path using `path.resolve`.
    3. Check that the normalized path starts with the root directory.
    4. If the path is not within the root directory, throw an error or return an appropriate response.
    
  </details>


- https://github.com/octodemo/brokencrystals/security/code-scanning/7
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This involves normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. If the path is not within the root directory, we should throw an error or handle it appropriately.

    1. Define a safe root directory.
    2. Normalize the user-provided file path using `path.resolve`.
    3. Check if the normalized path starts with the root directory.
    4. If the path is not within the root directory, throw an error or handle it appropriately.
    
  </details>


- https://github.com/octodemo/brokencrystals/security/code-scanning/6
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the file path is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. We will introduce a constant `ROOT` to define the safe root directory and update the `getFile` and `deleteFile` methods to include this validation.
    
  </details>


- https://github.com/octodemo/brokencrystals/security/code-scanning/5
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the `file` parameter is validated and sanitized before being used in file system operations. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. This involves:

    1. Defining a safe root directory.
    2. Normalizing the `file` path using `path.resolve`.
    3. Checking that the normalized path starts with the root directory.
    
  </details>


- https://github.com/octodemo/brokencrystals/security/code-scanning/4
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the user-provided `file` path is validated and sanitized before being used in file system operations. We can achieve this by normalizing the path using `path.resolve` and ensuring it is contained within a predefined safe root directory. This will prevent directory traversal attacks and ensure that the file operations are performed within a controlled environment.

    1. Define a safe root directory.
    2. Normalize the user-provided `file` path using `path.resolve`.
    3. Check that the normalized path starts with the safe root directory.
    4. If the path is not valid, log an error and return an appropriate response.
    
  </details>


- https://github.com/octodemo/brokencrystals/security/code-scanning/3
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the `file` path provided by the user is validated and sanitized before it is used in any file system operations. The best way to achieve this is to resolve the path relative to a safe root directory and ensure that the resolved path is within the intended directory. This can be done using the `path.resolve` and `fs.realpathSync` methods.

    1. Define a safe root directory.
    2. Resolve the user-provided path relative to the safe root directory.
    3. Check that the resolved path starts with the safe root directory.
    4. If the check fails, handle the error appropriately (e.g., log the error and return a 403 Forbidden response).
    
  </details>


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
