### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^6.6.3",
-    "stream-buffers": "^3.0.2"
+    "stream-buffers": "^3.0.2",
+    "shell-quote": "^1.8.1"
   },
   "devDependencies": {
     "@mikro-orm/cli": "^4.3.3",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { spawn } from 'child_process';
+import * as shellQuote from 'shell-quote';
 import * as dotT from 'dot';
 import { parseXml } from 'libxmljs';
 import { AppConfig } from './app.config.api';
@@ -112,7 +113,8 @@ export class AppController {
 
     return new Promise((res, rej) => {
       try {
-        const [exec, ...args] = command.split(' ');
+        const parsedCommand = shellQuote.parse(command);
+        const [exec, ...args] = parsedCommand;
         const ps = spawn(exec, args);
 
         ps.stdout.on('data', (data: Buffer) => {


### PR DESCRIPTION
Potential fix for [https://github.com/octodemo/brokencrystals/security/code-scanning/12](https://github.com/octodemo/brokencrystals/security/code-scanning/12) from the [Critical CMD Line Injection has Copilot AutoFix](https://github.com/orgs/octodemo/security/campaigns/243) security campaign.

To fix this issue, we should avoid using `spawn` with user-provided input directly. Instead, we can use a library like `shell-quote` to safely parse the user input into an array of arguments. This approach ensures that the input is treated as arguments rather than a single concatenated string, which mitigates the risk of command injection.

1. Install the `shell-quote` library.
2. Import the `shell-quote` library in the file.
3. Use `shell-quote` to parse the `command` string into an array of arguments.
4. Pass the parsed arguments to `spawn`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
